### PR TITLE
ログアウト処理の改善　デプロイ失敗後

### DIFF
--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -7,7 +7,7 @@
       <% if current_user %>
         <%= link_to 'Create', new_template_path, data: { turbo: false } %>
         &nbsp;&nbsp;&nbsp;&nbsp;
-        <%= link_to 'Logout', logout_path, method: :delete, data: { turbo: false, turbo_method: :delete } %>
+        <%= button_to 'Logout', logout_path, method: :delete, data: { turbo: false } %>
       <% else %>
         <%= link_to 'Login', login_path, data: { turbo: false } %>
         &nbsp;&nbsp;&nbsp;&nbsp;

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
   get "signup", to: "users#new", as: "signup"
   get "login", to: "user_sessions#new", as: "login"
   post "login", to: "user_sessions#create"
-  get "logout", to: "user_sessions#destroy", as: "logout"
+  delete "logout", to: "user_sessions#destroy", as: "logout"
 
   resources :users, only: %i[new create]
   resources :templates, only: %i[index new create show edit update destroy]


### PR DESCRIPTION
デプロイに失敗する原因が特定できなかったため、直近でデプロイできていた状態へ戻し、再度ログアウト機能の改善を施した。